### PR TITLE
Update packages to use new Flow tool

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,11 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+
+[strict]

--- a/install/package.json
+++ b/install/package.json
@@ -15,7 +15,9 @@
     "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
     "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
     "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "remove-flow-types": "flow-remove-types src/ -d dist/",
+    "flow": "flow"
   },
   "nyc": {
     "exclude": [
@@ -163,6 +165,8 @@
     "eslint": "^8.31.0",
     "eslint-config-nodebb": "0.2.1",
     "eslint-plugin-import": "2.26.0",
+    "flow-bin": "^0.231.0",
+    "flow-remove-types": "^2.231.0",
     "grunt": "1.5.3",
     "grunt-contrib-watch": "1.1.0",
     "husky": "8.0.2",


### PR DESCRIPTION
This pull request updates our project to use the new static analysis flow tool. The changes include modifications to the `install/package.json` file to incorporate the new flow tool in our scripts. It additionally provides the dependency remove-flow-types package within `install/package.json`

To use, run `npm run flow` on the terminal. 

Proof that this has ran successfully:

```plaintext
(base) alin@Alberts-MacBook-Pro-4 spring24-nodebb-allegra % npm run flow init

> nodebb@2.8.1 flow
> flow init

(base) alin@Alberts-MacBook-Pro-4 spring24-nodebb-allegra % npm run flow

> nodebb@2.8.1 flow
> flow

Launching Flow server for /Users/alin/codestuff/spring24-nodebb-allegra
Spawned flow server (pid=41189)
Logs will go to /private/tmp/flow/zSUserszSalinzScodestuffzSspring24-nodebb-allegra.log
Monitor logs will go to /private/tmp/flow/zSUserszSalinzScodestuffzSspring24-nodebb-allegra.monitor_log
No errors!
(base) alin@Alberts-MacBook-Pro-4 spring24-nodebb-allegra %